### PR TITLE
Configure artifacts as file set instead of distribution

### DIFF
--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -29,11 +29,9 @@ project:
     version: 11
     groupId: dev.morling.demos
 
-distributions:
-  kcetcd:
-    type: JAVA_BINARY
-    artifacts:
-      - path: target/distributions/{{distributionName}}-{{projectVersion}}.tar.gz
-        transform: '{{distributionName}}/{{distributionName}}-{{projectEffectiveVersion}}.tar.gz'
-      - path: target/distributions/{{distributionName}}-{{projectVersion}}.zip
-        transform: '{{distributionName}}/{{distributionName}}-{{projectEffectiveVersion}}.zip'
+files:
+  artifacts:
+    - path: target/distributions/kcetcd-{{projectVersion}}.tar.gz
+      transform: 'kcetcd-{{projectEffectiveVersion}}.tar.gz'
+    - path: target/distributions/kcetcd-{{projectVersion}}.zip
+      transform: 'kcetcd-{{projectEffectiveVersion}}.zip'


### PR DESCRIPTION
Configuring artifacts in the `files:` section leads to the same results as before but prevents the use of `packagers:` such as Homebrew.